### PR TITLE
feat: add Turnitin report upload functionality and email reminders

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model sponsor {
 
 model speaker {
   id              String       @id @default(uuid())
+  paperId   String    // <— new field for paper ID
   
   // Conference Information
   conferenceTitle String
@@ -74,6 +75,7 @@ model speaker {
   paperFileUrl    String?
   supplementaryFileUrl String?
   sourceCodeFileUrl String?
+  turnitinReportUrl  String?  
   
   // Additional Declarations
   ethicsCompliance Boolean     @default(false)
@@ -114,6 +116,9 @@ model speaker {
   
   createdAt       DateTime     @default(now())
   updatedAt       DateTime     @updatedAt
+  // Automated reminder tracking
+  reviewReminderCount       Int       @default(0)
+  reviewReminderLastSentAt  DateTime?
 }
 
 enum AttendeeType {

--- a/src/app.js
+++ b/src/app.js
@@ -13,6 +13,7 @@ import adminRoutes from './routes/adminRoutes.js';
 import userRoutes from './routes/userRoutes.js';
 import contactRoutes from './routes/contact.js';
 import reviewerExpressionRoutes from "./routes/reviewerExpressionRoutes.js";
+import { startReviewReminderJob } from './jobs/reviewReminderJob.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -44,6 +45,7 @@ app.use(express.urlencoded({ extended: true }));
 
 // Connect to database
 connectDB();
+startReviewReminderJob();
 
 app.get('/', (req, res) => {
     res.send('Hello, World!');

--- a/src/config/reviewReminder.config.js
+++ b/src/config/reviewReminder.config.js
@@ -1,0 +1,9 @@
+export default {
+    INTERVAL_HOURS: 24,     // ← set to 0.0833 for testing
+    CHECK_EVERY_MIN: 60,    // ← set to 1 for testing
+    MAX_REMINDERS: 5,       // cap to avoid spam
+    DISABLED: false,        // set true to temporarily turn off the job
+};
+
+// INTERVAL_HOURS: 0.0833,     // ← set to 0.0833 for testing
+// CHECK_EVERY_MIN: 1,    // ← set to 1 for testing

--- a/src/controllers/reviewerExpressionController.js
+++ b/src/controllers/reviewerExpressionController.js
@@ -168,37 +168,140 @@ export const getReviewerExpressionById = async (req, res) => {
  * Super Admin only
  * body: { status: "PENDING" | "ACCEPTED" | "REJECTED" }
  */
+// export const updateReviewerExpressionStatus = async (req, res) => {
+//   try {
+//     const { id } = req.params;
+//     const { status } = req.body;
+
+//     if (!["PENDING", "ACCEPTED", "REJECTED"].includes(status)) {
+//       return res
+//         .status(400)
+//         .json({ success: false, message: "Invalid status" });
+//     }
+
+//     const updated = await prisma.ReviewerExpression.update({
+//       where: { id },
+//       data: { status },
+//     });
+
+//     return res.json({
+//       success: true,
+//       message: "Status updated",
+//       data: updated,
+//     });
+//   } catch (error) {
+//     console.error("updateReviewerExpressionStatus error:", error);
+//     if (error.code === "P2025") {
+//       return res
+//         .status(404)
+//         .json({ success: false, message: "Reviewer record not found" });
+//     }
+//     return res.status(500).json({ success: false, message: "Server error" });
+//   }
+// };
+
+
 export const updateReviewerExpressionStatus = async (req, res) => {
   try {
     const { id } = req.params;
     const { status } = req.body;
 
-    if (!["PENDING", "ACCEPTED", "REJECTED"].includes(status)) {
-      return res
-        .status(400)
-        .json({ success: false, message: "Invalid status" });
+    const VALID = ["PENDING", "ACCEPTED", "REJECTED"];
+    if (!VALID.includes(status)) {
+      return res.status(400).json({ success: false, message: "Invalid status" });
     }
 
-    const updated = await prisma.ReviewerExpression.update({
-      where: { id },
-      data: { status },
+    // We need existing data to sync on ACCEPTED
+    const existing = await prisma.ReviewerExpression.findUnique({ where: { id } });
+    if (!existing) {
+      return res.status(404).json({ success: false, message: "Reviewer record not found" });
+    }
+
+    // subjectArea (Json) -> string for ReviewingCommittee.expertise
+    const toExpertiseString = (v) => {
+      if (Array.isArray(v)) return v.filter(Boolean).join(", ");
+      if (typeof v === "string") return v.trim();
+      if (v && typeof v === "object") return Object.values(v).filter(Boolean).join(", ");
+      return "";
+    };
+
+    // NEW: define normPhone used below
+    const normPhone = (p) => (p == null ? null : String(p).trim() || null);
+
+    const adminId = req.admin?.id; // set by requireSuperAdmin
+    if (status === "ACCEPTED" && !adminId) {
+      return res.status(500).json({ success: false, message: "Admin context missing (createdBy required)" });
+    }
+
+    const result = await prisma.$transaction(async (tx) => {
+      // 1) Update ReviewerExpression status
+      const updated = await tx.ReviewerExpression.update({
+        where: { id },
+        data: { status },
+      });
+
+      // 2) If ACCEPTED, upsert into ReviewingCommittee using email as unique key
+      let committee = null;
+      if (status === "ACCEPTED") {
+        const email = (existing.email || "").trim();
+        if (email) {
+          committee = await tx.reviewingCommittee.upsert({
+            where: { email }, // @unique on ReviewingCommittee.email
+            create: {
+              name: existing.name,
+              email,
+              designation: existing.currentJobTitle,
+              institution: existing.institution,
+              expertise: toExpertiseString(existing.subjectArea),
+              phone: normPhone(existing.phone),     // ← now defined
+              isActive: true,
+              createdBy: adminId,
+            },
+            update: {
+              name: existing.name,
+              designation: existing.currentJobTitle,
+              institution: existing.institution,
+              expertise: toExpertiseString(existing.subjectArea),
+              phone: normPhone(existing.phone),     // ← now defined
+              isActive: true,
+            },
+          });
+        }
+      }
+
+      return { updated, committee };
     });
 
     return res.json({
       success: true,
       message: "Status updated",
-      data: updated,
+      data: result.updated,
+      syncedToCommittee: Boolean(result.committee),
+      committeeRecord: result.committee
+        ? {
+            id: result.committee.id,
+            name: result.committee.name,
+            email: result.committee.email,
+            designation: result.committee.designation,
+            institution: result.committee.institution,
+            expertise: result.committee.expertise,
+            isActive: result.committee.isActive,
+            createdBy: result.committee.createdBy,
+            createdAt: result.committee.createdAt,
+            updatedAt: result.committee.updatedAt,
+          }
+        : null,
     });
   } catch (error) {
     console.error("updateReviewerExpressionStatus error:", error);
     if (error.code === "P2025") {
-      return res
-        .status(404)
-        .json({ success: false, message: "Reviewer record not found" });
+      return res.status(404).json({ success: false, message: "Reviewer record not found" });
     }
     return res.status(500).json({ success: false, message: "Server error" });
   }
 };
+
+
 
 /**
  * DELETE /api/reviewer-expression/:id

--- a/src/controllers/reviewingCommitteeController.js
+++ b/src/controllers/reviewingCommitteeController.js
@@ -160,11 +160,46 @@ export const updateCommitteeMember = async (req, res) => {
 };
 
 // Delete committee member (Super Admin only)
+// export const deleteCommitteeMember = async (req, res) => {
+//   try {
+//     const { id } = req.params;
+
+//     // Check if member exists
+//     const existingMember = await prisma.reviewingCommittee.findUnique({
+//       where: { id }
+//     });
+
+//     if (!existingMember) {
+//       return res.status(404).json({
+//         success: false,
+//         message: 'Committee member not found'
+//       });
+//     }
+
+//     await prisma.reviewingCommittee.delete({
+//       where: { id }
+//     });
+
+//     res.status(200).json({
+//       success: true,
+//       message: 'Committee member deleted successfully'
+//     });
+//   } catch (error) {
+//     console.error('Error deleting committee member:', error);
+//     res.status(500).json({
+//       success: false,
+//       message: 'Failed to delete committee member',
+//       error: error.message
+//     });
+//   }
+// };
+
+// Delete committee member (Super Admin only)
 export const deleteCommitteeMember = async (req, res) => {
   try {
     const { id } = req.params;
 
-    // Check if member exists
+    // 1) Ensure the member exists (we need its email to find the source expression)
     const existingMember = await prisma.reviewingCommittee.findUnique({
       where: { id }
     });
@@ -176,13 +211,25 @@ export const deleteCommitteeMember = async (req, res) => {
       });
     }
 
-    await prisma.reviewingCommittee.delete({
-      where: { id }
-    });
+    const email = (existingMember.email || '').trim();
 
-    res.status(200).json({
+    // 2) Atomically delete the committee member and reset any matching reviewer expressions
+    const [deleted, resetResult] = await prisma.$transaction([
+      prisma.reviewingCommittee.delete({ where: { id } }),
+      // Only flip expressions that were ACCEPTED (i.e., “came from” an accepted application)
+      prisma.ReviewerExpression.updateMany({
+        where: {
+          email: email,
+          status: 'ACCEPTED'
+        },
+        data: { status: 'REJECTED' }
+      })
+    ]);
+
+    return res.status(200).json({
       success: true,
-      message: 'Committee member deleted successfully'
+      message: 'Committee member deleted successfully',
+      reviewerExpressionsReset: resetResult.count // how many expressions were set back to PENDING
     });
   } catch (error) {
     console.error('Error deleting committee member:', error);
@@ -193,6 +240,7 @@ export const deleteCommitteeMember = async (req, res) => {
     });
   }
 };
+
 
 // Send speaker to committee for review
 export const sendSpeakerToCommittee = async (req, res) => {

--- a/src/controllers/speakerController.js
+++ b/src/controllers/speakerController.js
@@ -1,7 +1,6 @@
 import { prisma } from "../config/db.js";
 import { sendSpeakerRegistrationEmail } from "../services/emailService.js";
 
-// Validation functions
 const validateEmail = (email) => {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);
@@ -18,16 +17,57 @@ const validateOrcid = (orcid) => {
   return orcidRegex.test(orcid);
 };
 
+// -------------------------------------------
+// PAPER ID HELPERS (GLOBAL, NEVER RESETS)
+// Format: YYMM + global serial (3 digits)
+// e.g. 2509011 for 2025 Sep, global #11
+// -------------------------------------------
+const SERIAL_PAD = 3;
+
+function formatPaperId(date, seq, pad = SERIAL_PAD) {
+  const yy = String(date.getFullYear()).slice(-2);
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const s  = String(seq).padStart(pad, "0");
+  return `${yy}${mm}${s}`;
+}
+
+/**
+ * Get the next global serial number by looking at the current
+ * maximum serial used in paperId (SUBSTRING from 5th char onward).
+ * If query fails (or no rows), fallback to count-based.
+ */
+async function getNextGlobalSerial() {
+  try {
+    // Works on MySQL: paperId like 'YYMMSSS' → serial is SUBSTRING from 5
+    const rows = await prisma.$queryRawUnsafe(`
+      SELECT MAX(CAST(SUBSTRING(paperId, 5) AS UNSIGNED)) AS maxSerial
+      FROM speaker
+      WHERE paperId IS NOT NULL
+    `);
+    const maxSerial = Number(rows?.[0]?.maxSerial) || 0;
+    return maxSerial + 1;
+  } catch (err) {
+    // Fallback if raw query not available
+    const c = await prisma.speaker.count({ where: { paperId: { not: null } } });
+    return c + 1;
+  }
+}
+
+// --------------------------
+// CONTROLLERS
+// --------------------------
 export const registerSpeaker = async (req, res) => {
   try {
     const speakerData = req.body;
     const { referralCode } = speakerData;
-    
-    // Handle file uploads
+
+    // --------------------------
+    // Handle file uploads (yours)
+    // --------------------------
     let paperFileUrl = null;
     let supplementaryFileUrl = null;
     let sourceCodeFileUrl = null;
-    
+
     if (req.files) {
       if (req.files.paperFile) {
         paperFileUrl = req.files.paperFile[0].path;
@@ -40,7 +80,9 @@ export const registerSpeaker = async (req, res) => {
       }
     }
 
-    // If referral code is provided, verify it exists
+    // ---------------------------------
+    // Referral code → find Admin (yours)
+    // ---------------------------------
     let referredById = null;
     if (referralCode) {
       const admin = await prisma.Admin.findUnique({
@@ -48,53 +90,49 @@ export const registerSpeaker = async (req, res) => {
       });
 
       if (!admin) {
-        return res.status(400).json({ 
-          message: 'Invalid referral code',
-          success: false 
+        return res.status(400).json({
+          message: "Invalid referral code",
+          success: false
         });
       }
       referredById = admin.id;
     }
 
-    // Validate required fields
+    // ----------------------------
+    // Required fields (your logic)
+    // ----------------------------
     const requiredFields = [
-      'conferenceTitle', 'placeDate', 'paperTitle', 'paperAbstract', 'keywords',
-      'name', 'email', 'phone', 'institutionName', 'country', 'primarySubject',
-      'ethicsCompliance', 'agreeTerms', 'agreePresentation', 'agreePublication',
-      'agreeReview', 'agreeDataSharing'
+      "conferenceTitle", "placeDate", "paperTitle", "paperAbstract", "keywords",
+      "name", "email", "phone", "institutionName", "country", "primarySubject",
+      "ethicsCompliance", "agreeTerms", "agreePresentation", "agreePublication",
+      "agreeReview", "agreeDataSharing"
     ];
-    
-    const missingFields = requiredFields.filter(field => {
-      if (field === 'ethicsCompliance' || field.startsWith('agree')) {
-        return !speakerData[field] || speakerData[field] !== 'true';
+
+    const missingFields = requiredFields.filter((field) => {
+      if (field === "ethicsCompliance" || field.startsWith("agree")) {
+        return !speakerData[field] || speakerData[field] !== "true";
       }
       return !speakerData[field];
     });
-    
+
     if (missingFields.length > 0) {
       return res.status(400).json({
-        message: `Missing required fields: ${missingFields.join(', ')}`,
+        message: `Missing required fields: ${missingFields.join(", ")}`,
         success: false
       });
     }
 
-    // Validate email format
+    // ---------------------------
+    // Field validations (yours)
+    // ---------------------------
     if (!validateEmail(speakerData.email)) {
-      return res.status(400).json({
-        message: "Invalid email format",
-        success: false
-      });
+      return res.status(400).json({ message: "Invalid email format", success: false });
     }
 
-    // Validate phone format
     if (!validatePhone(speakerData.phone)) {
-      return res.status(400).json({
-        message: "Invalid phone number format",
-        success: false
-      });
+      return res.status(400).json({ message: "Invalid phone number format", success: false });
     }
 
-    // Validate ORCID if provided
     if (speakerData.orcidId && !validateOrcid(speakerData.orcidId)) {
       return res.status(400).json({
         message: "Invalid ORCID format (should be 0000-0000-0000-0000)",
@@ -102,8 +140,8 @@ export const registerSpeaker = async (req, res) => {
       });
     }
 
-    // Validate abstract length
-    const abstractWords = speakerData.paperAbstract.trim().split(/\s+/).filter(word => word.length > 0);
+    // Abstract length (50–500 words)
+    const abstractWords = speakerData.paperAbstract.trim().split(/\s+/).filter(w => w.length > 0);
     if (abstractWords.length < 50) {
       return res.status(400).json({
         message: "Abstract must be at least 50 words long",
@@ -117,22 +155,24 @@ export const registerSpeaker = async (req, res) => {
       });
     }
 
-    // Validate conditional fields
-    if (speakerData.preprintPolicy === 'true' && !speakerData.preprintUrl) {
+    // Conditional fields
+    if (speakerData.preprintPolicy === "true" && !speakerData.preprintUrl) {
       return res.status(400).json({
         message: "Preprint URL is required when preprint policy is selected",
         success: false
       });
     }
 
-    if (speakerData.aiGeneratedContent === 'true' && !speakerData.aiContentDescription) {
+    if (speakerData.aiGeneratedContent === "true" && !speakerData.aiContentDescription) {
       return res.status(400).json({
         message: "AI content description is required when AI-generated content is selected",
         success: false
       });
     }
 
-    // Validate co-authors if any
+    // -----------------------------
+    // Co-authors JSON validation
+    // -----------------------------
     let coAuthors = [];
     if (speakerData.coAuthors) {
       try {
@@ -166,11 +206,12 @@ export const registerSpeaker = async (req, res) => {
       }
     }
 
-    // Check if email already exists
+    // -------------------------------------
+    // Unique email (your existing check)
+    // -------------------------------------
     const existingSpeaker = await prisma.speaker.findUnique({
       where: { email: speakerData.email }
     });
-
     if (existingSpeaker) {
       return res.status(400).json({
         message: "Speaker already registered with this email",
@@ -178,17 +219,19 @@ export const registerSpeaker = async (req, res) => {
       });
     }
 
-    // Prepare data for database insertion
+    // -------------------------------------
+    // Prepare DB payload (yours)
+    // -------------------------------------
     const speakerCreateData = {
       // Conference Information
       conferenceTitle: speakerData.conferenceTitle,
       placeDate: speakerData.placeDate,
-      
+
       // Paper Information
       paperTitle: speakerData.paperTitle,
       paperAbstract: speakerData.paperAbstract,
       keywords: speakerData.keywords,
-      
+
       // Primary Author Information
       name: speakerData.name,
       email: speakerData.email,
@@ -196,58 +239,91 @@ export const registerSpeaker = async (req, res) => {
       institutionName: speakerData.institutionName,
       country: speakerData.country,
       orcidId: speakerData.orcidId || null,
-      isCorrespondingAuthor: speakerData.correspondingAuthor === 'true',
-      
-      // Co-authors Information
+      isCorrespondingAuthor: speakerData.correspondingAuthor === "true",
+
+      // Co-authors
       coAuthors: coAuthors.length > 0 ? JSON.stringify(coAuthors) : null,
-      
+
       // Subject Areas
       primarySubject: speakerData.primarySubject,
       additionalSubjects: speakerData.additionalSubjects || null,
-      
+
       // File Uploads
-      paperFileUrl: paperFileUrl,
-      supplementaryFileUrl: supplementaryFileUrl,
-      sourceCodeFileUrl: sourceCodeFileUrl,
-      
-      // Additional Declarations
-      ethicsCompliance: speakerData.ethicsCompliance === 'true',
-      dataAvailability: speakerData.dataAvailability === 'true',
-      preprintPolicy: speakerData.preprintPolicy === 'true',
+      paperFileUrl,
+      supplementaryFileUrl,
+      sourceCodeFileUrl,
+
+      // Declarations
+      ethicsCompliance: speakerData.ethicsCompliance === "true",
+      dataAvailability: speakerData.dataAvailability === "true",
+      preprintPolicy: speakerData.preprintPolicy === "true",
       preprintUrl: speakerData.preprintUrl || null,
-      conflictOfInterest: speakerData.conflictOfInterest === 'true',
-      
+      conflictOfInterest: speakerData.conflictOfInterest === "true",
+
       // Supplementary Questions
-      previouslySubmitted: speakerData.previouslySubmitted === 'true',
+      previouslySubmitted: speakerData.previouslySubmitted === "true",
       previousSubmissionInfo: speakerData.previousSubmissionInfo || null,
-      willingToReview: speakerData.willingToReview === 'true',
-      aiGeneratedContent: speakerData.aiGeneratedContent === 'true',
+      willingToReview: speakerData.willingToReview === "true",
+      aiGeneratedContent: speakerData.aiGeneratedContent === "true",
       aiContentDescription: speakerData.aiContentDescription || null,
-      studentPaper: speakerData.studentPaper === 'true',
-      
+      studentPaper: speakerData.studentPaper === "true",
+
       // Agreements
-      agreeTerms: speakerData.agreeTerms === 'true',
-      agreePresentation: speakerData.agreePresentation === 'true',
-      agreePublication: speakerData.agreePublication === 'true',
-      agreeReview: speakerData.agreeReview === 'true',
-      agreeDataSharing: speakerData.agreeDataSharing === 'true',
-      
-      // Additional Information
+      agreeTerms: speakerData.agreeTerms === "true",
+      agreePresentation: speakerData.agreePresentation === "true",
+      agreePublication: speakerData.agreePublication === "true",
+      agreeReview: speakerData.agreeReview === "true",
+      agreeDataSharing: speakerData.agreeDataSharing === "true",
+
+      // Additional
       message: speakerData.message || null,
       referralCode: referralCode || null,
       referredById: referredById,
-      
-      // Legacy fields for backward compatibility
-      attendeeType: 'presenter',
+
+      // Legacy
+      attendeeType: "presenter",
       fileUrl: paperFileUrl
     };
 
-    // Create new speaker
-    const newSpeaker = await prisma.speaker.create({
-      data: speakerCreateData,
-    });
+    // --------------------------------------------------------
+    // CREATE WITH GLOBAL PAPER ID (unique + concurrency safe)
+    // --------------------------------------------------------
+    const now = new Date();
+    let serial = await getNextGlobalSerial();
+    let newSpeaker = null;
 
-    // If referral code exists, create the user record with admin reference
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const candidatePaperId = formatPaperId(now, serial);
+
+      try {
+        newSpeaker = await prisma.speaker.create({
+          data: {
+            ...speakerCreateData,
+            paperId: candidatePaperId, // <-- NEW FIELD HERE
+          },
+        });
+        break; // success
+      } catch (e) {
+        // On unique violation for paperId, bump serial and retry
+        if (e.code === "P2002" && String(e?.meta?.target || "").includes("paperId")) {
+          serial += 1;
+          continue;
+        }
+        // Other errors: rethrow
+        throw e;
+      }
+    }
+
+    if (!newSpeaker) {
+      return res.status(500).json({
+        message: "Could not allocate a unique Paper ID. Please retry.",
+        success: false,
+      });
+    }
+
+    // ------------------------------------------
+    // Create user record if referralCode present
+    // ------------------------------------------
     if (referralCode && referredById) {
       await prisma.user.create({
         data: {
@@ -259,39 +335,43 @@ export const registerSpeaker = async (req, res) => {
       });
     }
 
-    // Send registration confirmation emails
+    // ---------------------------
+    // Send confirmation emails
+    // (templates can now show ${paperId})
+    // ---------------------------
     await sendSpeakerRegistrationEmail(newSpeaker);
 
+    // ---------------------------
+    // Final response
+    // ---------------------------
     res.status(201).json({
       message: "Paper submission successful",
       user: newSpeaker,
       success: true,
     });
   } catch (error) {
-    console.error('Speaker registration error:', error);
-    
-    // Handle specific Prisma errors
-    if (error.code === 'P2000') {
+    console.error("Speaker registration error:", error);
+
+    // Prisma error handling (yours)
+    if (error.code === "P2000") {
       return res.status(400).json({
         message: "One or more fields contain data that is too long. Please check your input and try again.",
-        success: false
+        success: false,
       });
     }
-    
-    if (error.code === 'P2002') {
+    if (error.code === "P2002") {
       return res.status(400).json({
         message: "A submission with this email address already exists. Please use a different email or contact support.",
-        success: false
+        success: false,
       });
     }
-    
-    if (error.code === 'P2003') {
+    if (error.code === "P2003") {
       return res.status(400).json({
         message: "Invalid reference data. Please check your form and try again.",
-        success: false
+        success: false,
       });
     }
-    
+
     res.status(500).json({
       message: "Error submitting paper. Please try again later or contact support if the problem persists.",
       error: error.message,
@@ -304,18 +384,18 @@ export const getSpeakers = async (req, res) => {
   try {
     const { page = 1, limit = 10, status, search } = req.query;
     const skip = (parseInt(page) - 1) * parseInt(limit);
-    
-    // Build where clause
+
     const where = {};
-    if (status && status !== 'ALL') {
+    if (status && status !== "ALL") {
       where.reviewStatus = status;
     }
     if (search) {
       where.OR = [
-        { name: { contains: search, mode: 'insensitive' } },
-        { email: { contains: search, mode: 'insensitive' } },
-        { paperTitle: { contains: search, mode: 'insensitive' } },
-        { institutionName: { contains: search, mode: 'insensitive' } }
+        { name: { contains: search, mode: "insensitive" } },
+        { email: { contains: search, mode: "insensitive" } },
+        { paperTitle: { contains: search, mode: "insensitive" } },
+        { institutionName: { contains: search, mode: "insensitive" } },
+        { paperId: { contains: search, mode: "insensitive" } }, // <— allow searching by Paper ID
       ];
     }
 
@@ -324,29 +404,25 @@ export const getSpeakers = async (req, res) => {
         where,
         skip,
         take: parseInt(limit),
-        orderBy: { createdAt: 'desc' },
+        orderBy: { createdAt: "desc" },
         include: {
           referredBy: {
-            select: {
-              id: true,
-              email: true,
-              referralCode: true
-            }
+            select: { id: true, email: true, referralCode: true }
           }
         }
       }),
       prisma.speaker.count({ where })
     ]);
 
-    res.status(200).json({ 
-      speakers, 
+    res.status(200).json({
+      speakers,
       total,
       page: parseInt(page),
       totalPages: Math.ceil(total / parseInt(limit)),
-      success: true 
+      success: true
     });
   } catch (error) {
-    console.error('Error retrieving speakers:', error);
+    console.error("Error retrieving speakers:", error);
     res.status(500).json({
       message: "Error retrieving speakers",
       error: error.message,
@@ -354,6 +430,7 @@ export const getSpeakers = async (req, res) => {
     });
   }
 };
+
 
 export const getSpeakerById = async (req, res) => {
   try {
@@ -501,6 +578,44 @@ export const getSpeakerStats = async (req, res) => {
       message: "Error retrieving speaker statistics",
       error: error.message,
       success: false,
+    });
+  }
+};
+
+
+export const uploadTurnitinReport = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const speaker = await prisma.speaker.findUnique({ where: { id } });
+    if (!speaker) {
+      return res.status(404).json({ message: "Speaker not found", success: false });
+    }
+
+    if (!req.file && !(req.files && req.files.turnitinReport && req.files.turnitinReport[0])) {
+      return res.status(400).json({ message: "No report file uploaded", success: false });
+    }
+
+    // Cloudinary multer gives you .path
+    const reportFile = req.file ? req.file : req.files.turnitinReport[0];
+    const url = reportFile.path;
+
+    const updated = await prisma.speaker.update({
+      where: { id },
+      data: { turnitinReportUrl: url }
+    });
+
+    return res.status(200).json({
+      message: "Turnitin report uploaded successfully",
+      speaker: updated,
+      success: true
+    });
+  } catch (err) {
+    console.error("Error uploading Turnitin report:", err);
+    return res.status(500).json({
+      message: "Failed to upload Turnitin report",
+      error: err.message,
+      success: false
     });
   }
 };

--- a/src/jobs/reviewReminderJob.js
+++ b/src/jobs/reviewReminderJob.js
@@ -1,0 +1,153 @@
+// src/jobs/reviewReminderJob.js
+import { prisma } from "../config/db.js";
+import { sendReviewReminderEmail } from "../services/emailService.js";
+import reminderCfg from "../config/reviewReminder.config.js";
+import { isMailerBlocked, nextSendTime } from "../services/mailerGuard.js";
+/**
+ * Sends reminder emails to committee members every N hours
+ * for speakers still awaiting a decision. Stops once reviewStatus is
+ * APPROVED / REJECTED / NEEDS_REVISION.
+ *
+ * Tuning via .env:
+ *   REVIEW_REMINDER_INTERVAL_HOURS  (default 24)
+ *   REVIEW_REMINDER_CHECK_MINUTES   (default 60)
+ *   REVIEW_REMINDER_MAX             (default 7)
+ */
+const HOURS = Number(reminderCfg.INTERVAL_HOURS ?? 24); // allows 0.0833, etc.
+const CHECK_EVERY_MIN = Number(reminderCfg.CHECK_EVERY_MIN ?? 60);
+const MAX_REMINDERS = Number(reminderCfg.MAX_REMINDERS ?? 7);
+
+function safeParseJSON(v, fallback = null) {
+  try {
+    if (!v) return fallback;
+    if (typeof v === "object") return v;
+    return JSON.parse(v);
+  } catch {
+    return fallback;
+  }
+}
+
+function hoursBetween(a, b) {
+  return Math.abs((a.getTime() - b.getTime()) / (1000 * 60 * 60));
+}
+
+function earliestSentAt(committeeMembers) {
+  const arr = safeParseJSON(committeeMembers, []);
+  const dates = (arr || [])
+    .map((m) => (m?.sentAt ? new Date(m.sentAt) : null))
+    .filter(Boolean);
+  if (!dates.length) return null;
+  return new Date(Math.min(...dates.map((d) => d.getTime())));
+}
+
+function shouldSendReminder(speaker) {
+  if (!speaker.sentToCommittee) return false;
+  if (["APPROVED", "REJECTED", "NEEDS_REVISION"].includes(speaker.reviewStatus))
+    return false;
+  if ((speaker.reviewReminderCount || 0) >= MAX_REMINDERS) return false;
+
+  const last = speaker.reviewReminderLastSentAt
+    ? new Date(speaker.reviewReminderLastSentAt)
+    : null;
+  const firstSent =
+    earliestSentAt(speaker.committeeMembers) ||
+    new Date(speaker.updatedAt || speaker.createdAt);
+  const reference = last || firstSent;
+  if (!reference) return true;
+
+  return hoursBetween(new Date(), reference) >= HOURS;
+}
+
+async function sendRemindersForSpeaker(speaker) {
+  const members = safeParseJSON(speaker.committeeMembers, []) || [];
+  if (!members.length) return;
+
+  const results = await Promise.allSettled(
+    members.map((m) => sendReviewReminderEmail(speaker, m))
+  );
+
+  await prisma.speaker.update({
+    where: { id: speaker.id },
+    data: {
+      reviewReminderCount: (speaker.reviewReminderCount || 0) + 1,
+      reviewReminderLastSentAt: new Date(),
+    },
+  });
+
+  const ok = results.filter((r) => r.status === "fulfilled").length;
+  const fail = results.length - ok;
+  console.log(
+    `[ReviewReminderJob] ${
+      speaker.paperId || speaker.id
+    }: sent=${ok}, failed=${fail}`
+  );
+}
+
+export function startReviewReminderJob() {
+  if (reminderCfg.DISABLED) {
+    console.log("[ReviewReminderJob] disabled via config");
+    return;
+  }
+  console.log(
+    `[ReviewReminderJob] started — checks every ${CHECK_EVERY_MIN} min; interval=${HOURS}h; max=${MAX_REMINDERS}`
+  );
+
+  const tick = async () => {
+    try {
+      if (isMailerBlocked()) {
+        console.warn(
+          `[ReviewReminderJob] Mailer in cooldown; skipping reminders until ${new Date(
+            nextSendTime()
+          ).toISOString()}`
+        );
+        return;
+      }
+      const speakers = await prisma.speaker.findMany({
+        where: {
+          sentToCommittee: true,
+          reviewStatus: {
+            in: ["PENDING", "SENT_TO_COMMITTEE", "UNDER_REVIEW"],
+          },
+        },
+        select: {
+          id: true,
+          paperId: true,
+          paperTitle: true,
+          name: true,
+          email: true,
+          paperFileUrl: true,
+          fileUrl: true,
+          turnitinReportUrl: true,
+          committeeMembers: true,
+          reviewStatus: true,
+          sentToCommittee: true,
+          createdAt: true,
+          updatedAt: true,
+          reviewReminderCount: true,
+          reviewReminderLastSentAt: true,
+        },
+      });
+
+      let processed = 0,
+        sent = 0;
+      for (const s of speakers) {
+        processed++;
+        if (shouldSendReminder(s)) {
+          await sendRemindersForSpeaker(s);
+          sent++;
+        }
+      }
+      if (processed)
+        console.log(
+          `[ReviewReminderJob] scanned=${processed}, remindersSent=${sent}`
+        );
+    } catch (err) {
+      console.error("[ReviewReminderJob] error:", err?.message || err);
+    }
+  };
+
+  // Run immediately, then on interval
+  //   tick();
+  setTimeout(tick, 60 * 1000);
+  setInterval(tick, CHECK_EVERY_MIN * 60 * 1000);
+}

--- a/src/routes/speakerRoutes.js
+++ b/src/routes/speakerRoutes.js
@@ -5,7 +5,8 @@ import {
   getSpeakerById, 
   updateSpeakerStatus, 
   deleteSpeaker, 
-  getSpeakerStats 
+  getSpeakerStats,
+  uploadTurnitinReport
 } from "../controllers/speakerController.js";
 import { upload } from "../config/cloudinary.js";
 
@@ -61,5 +62,14 @@ router.patch("/speakers/:id/status", updateSpeakerStatus);
 
 // Delete speaker (admin only)
 router.delete("/speakers/:id", deleteSpeaker);
+
+
+// Upload turnitin report
+router.post(
+  "/speakers/:id/turnitin-report",
+  upload.single('turnitinReport'),
+  handleUploadError,
+  uploadTurnitinReport
+);
 
 export default router;

--- a/src/services/mailerGuard.js
+++ b/src/services/mailerGuard.js
@@ -1,0 +1,26 @@
+let cooldownUntil = 0;
+
+// Default 25h to be safe; adjust if you want
+const DEFAULT_COOLDOWN_MS = 25 * 60 * 60 * 1000;
+
+export function isMailerBlocked() {
+  return Date.now() < cooldownUntil;
+}
+export function nextSendTime() {
+  return cooldownUntil;
+}
+export function tripMailerCooldown(ms = DEFAULT_COOLDOWN_MS) {
+  cooldownUntil = Date.now() + ms;
+  console.warn(
+    `[MailerGuard] Cooling down until ${new Date(cooldownUntil).toISOString()}`
+  );
+}
+
+// Decide if an error is a Gmail daily limit block
+export function shouldCooldownFor(err) {
+  const msg = `${err?.response || ""} ${err?.message || ""}`.toLowerCase();
+  return (
+    err?.responseCode === 550 &&
+    (msg.includes("5.4.5") || msg.includes("daily user sending") || msg.includes("quota exceeded"))
+  );
+}

--- a/src/utils/emailTemplates/userRegistration.js
+++ b/src/utils/emailTemplates/userRegistration.js
@@ -163,6 +163,7 @@ export const speakerConfirmationTemplate = (speakerData) => `
       
       <div class="highlight">
         <h3>📋 Your Submission Details</h3>
+        <p><strong>Paper ID:</strong> ${speakerData.paperId}</p>
         <p><strong>Paper Title:</strong> ${speakerData.paperTitle}</p>
         <p><strong>Institution:</strong> ${speakerData.institutionName}</p>
         <p><strong>Conference Track:</strong> ${speakerData.conferenceTitle}</p>


### PR DESCRIPTION
- Implemented a new route for uploading Turnitin reports in speakerRoutes.js.
- Enhanced email service to include attachments for Turnitin reports and papers in review reminder emails.
- Introduced a review reminder job that sends periodic reminders to committee members for pending reviews.
- Added a mailer guard to manage sending limits and cooldowns for email dispatch.
- Updated email templates to include paper ID and Turnitin report links for better clarity.
- Configured review reminder settings in a new config file for easier adjustments.